### PR TITLE
RAML uploader - Auth token issue in single user mode

### DIFF
--- a/src/main/java/com/smockin/admin/service/ApiImportRouter.java
+++ b/src/main/java/com/smockin/admin/service/ApiImportRouter.java
@@ -58,10 +58,6 @@ public class ApiImportRouter {
             throw new ValidationException("Inbound config (in dto) is undefined");
         }
 
-        if (token == null) {
-            throw new ValidationException("Auth token is undefined");
-        }
-
     }
 
 }

--- a/src/test/java/com/smockin/admin/service/ApiImportRouterTest.java
+++ b/src/test/java/com/smockin/admin/service/ApiImportRouterTest.java
@@ -107,19 +107,6 @@ public class ApiImportRouterTest {
     }
 
     @Test
-    public void route_nullToken_Fail() throws ApiImportException, ValidationException {
-
-        // Assertions
-        expected.expect(ValidationException.class);
-        expected.expectMessage("Auth token is undefined");
-
-        // Test
-        apiImportRouter.route(ApiImportTypeEnum.RAML.name(), dto, null);
-
-        Mockito.verify(ramlApiImportService, Mockito.never()).importApiDoc(Matchers.any(ApiImportDTO.class), Matchers.anyString());
-    }
-
-    @Test
     public void route_nullConfig_Fail() throws ApiImportException, ValidationException {
 
         // Setup


### PR DESCRIPTION
Fixed issue with auth token being expected by RAML uploader when the app is not running in multi user mode.