### PR TITLE
add docker

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,9 +23,8 @@ binary
 TODO
 standalone
 build_all_distributions.sh
-Dockerfile
-launch.sh
 /src/test/java/com/smockin/localtemp
 sMockin.app
 *.zip
 debug.sh
+.vscode/settings.json

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,38 @@
+FROM maven:3.3-jdk-8 as BUILD
+RUN mkdir /app
+WORKDIR /app
+ADD pom.xml /app/pom.xml
+RUN mvn install
+ADD src /app/src
+RUN mvn package
+
+FROM openjdk:8-jre as RUN
+ARG APP_VERSION_ARG=2.19.0
+RUN mkdir /app
+RUN mkdir /app/db
+RUN mkdir /app/db/data
+RUN mkdir /app/db/driver
+RUN mkdir /app/log
+WORKDIR /app
+COPY install/h2-2.1.212.jar /app/db/driver/h2-2.1.212.jar
+COPY install/smockin_db.mv.db /app/db/data/smockin_db.mv.db
+COPY --from=BUILD /app/target/smockin-${APP_VERSION_ARG}.jar /app/smockin-${APP_VERSION_ARG}.jar
+COPY launch.sh /app/launch.sh
+EXPOSE 8000
+EXPOSE 8001
+EXPOSE 8002
+EXPOSE 8003
+
+ENV APP_VERSION=${APP_VERSION_ARG}
+ENV spring_database_driverClassName=org.h2.Driver
+ENV spring_datasource_url="jdbc:h2:tcp://localhost:9092//app/db/data/smockin_db"
+ENV spring_datasource_username=smockin
+ENV spring_datasource_password=smockin
+ENV spring_datasource_maximumPoolSize=10
+ENV spring_datasource_minimumIdle=10
+ENV SERVER_PORT=8000
+ENV MULTI_USER_MODE=FALSE
+ENV logging_file=/app/log/smockin.log
+
+RUN chmod +x /app/launch.sh
+ENTRYPOINT ["/app/launch.sh"]

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,31 @@
+version: "3.9"
+
+services:
+  smokin:
+    image: smokin
+    build:
+      context: .
+      dockerfile: Dockerfile
+    environment:
+      spring_jpa_database: POSTGRESQL
+      spring_datasource_platform: postgres
+      spring_jpa_show-sql: "true"
+      spring_jpa_hibernate_ddl-auto: create-drop
+      spring_database_driverClassName: org.postgresql.Driver
+      spring_datasource_url: jdbc:postgresql://database:5432/postgres
+      spring_datasource_username: postgres
+      spring_datasource_password: postgres
+      server_port: "8000"
+    ports: 
+      - "8000:8000"
+      - "8001:8001"
+      - "8002:8002"
+      - "8003:8003"
+    depends_on:
+      - database
+  database:
+    image: postgres
+    ports:
+      - "5432:5432"
+    environment:
+      POSTGRES_PASSWORD: postgres

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,8 +1,8 @@
 version: "3.9"
 
 services:
-  smokin:
-    image: smokin
+  smockin:
+    image: smockin
     build:
       context: .
       dockerfile: Dockerfile

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -10,7 +10,7 @@ services:
       spring_jpa_database: POSTGRESQL
       spring_datasource_platform: postgres
       spring_jpa_show-sql: "true"
-      spring_jpa_hibernate_ddl-auto: create-drop
+      spring_jpa_hibernate_ddl-auto: update
       spring_database_driverClassName: org.postgresql.Driver
       spring_datasource_url: jdbc:postgresql://database:5432/postgres
       spring_datasource_username: postgres

--- a/launch.sh
+++ b/launch.sh
@@ -1,0 +1,15 @@
+#!/bin/sh
+
+if ["$spring_database_driverClassName" == "org.h2.Driver"]; then
+
+    H2_DB_JAR="h2-2.1.212"
+
+    DB_HOME="/app/db"
+    DB_DATA_PATH="$DB_HOME/data/smockin_db"
+
+
+    java -cp $DB_HOME/driver/$H2_DB_JAR.jar org.h2.tools.Server -tcp -tcpAllowOthers -tcpPort 9092 &
+
+fi
+
+java -Dspring.profiles.active=production -Dapp.version=$APP_VERSION -Duser.timezone=UTC -jar smockin-$APP_VERSION.jar 

--- a/pom.xml
+++ b/pom.xml
@@ -22,6 +22,7 @@
         <spring-boot-test.version>2.6.7</spring-boot-test.version>
         <spark-core.version>2.9.1</spark-core.version>
         <h2.version>2.1.212</h2.version>
+        <postgresql.version>42.2.1</postgresql.version>
         <hikaricp.version>2.6.1</hikaricp.version>
         <commons-lang3.version>3.5</commons-lang3.version>
         <httpclient.version>4.5.13</httpclient.version>
@@ -85,6 +86,11 @@
             <groupId>com.zaxxer</groupId>
             <artifactId>HikariCP</artifactId>
             <version>${hikaricp.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.postgresql</groupId>
+            <artifactId>postgresql</artifactId>
+            <version>${postgresql.version}</version>
         </dependency>
 
         <!-- Apache Commons -->

--- a/src/main/java/com/smockin/admin/persistence/entity/Identifier.java
+++ b/src/main/java/com/smockin/admin/persistence/entity/Identifier.java
@@ -13,7 +13,7 @@ import java.util.Date;
 @Data
 public abstract class Identifier {
 
-    final int VARCHAR_MAX_VALUE = 1000000000;
+    final int VARCHAR_MAX_VALUE = 10485760;
 
     @Id
     @Column(name = "ID", nullable = false, unique = true, updatable = false)

--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -19,9 +19,10 @@
 
     <logger name="com.smockin.admin.persistence.migration" level="INFO">
         <appender-ref ref="smockin_appender" />
+        <appender-ref ref="STDOUT" />
     </logger>
 
-    <root level="ERROR">
+    <root level="INFO">
         <appender-ref ref="STDOUT" />
     </root>
 


### PR DESCRIPTION
These changes are to store the state outside the container, the next step is to add the Helm chart to the project. We leave the container with the local database working.

- we bring back the lauch.sh with some changes
- the spring configuration parameters are read from environment variables
- add docker-compose with postgres
- changed `VARCHAR_MAX_VALUE` to match PostgreSQL specs
- changed log to Info to improve verbosity in container startup and running.